### PR TITLE
Modify Index constructor

### DIFF
--- a/pymilvus_orm/collection.py
+++ b/pymilvus_orm/collection.py
@@ -561,8 +561,9 @@ class Collection(object):
         # TODO(yukun): Need field name, but provide index name, require some impl in server
         conn = self._get_connection()
         tmp_index = conn.describe_index(self._name, "")
+        field_name = tmp_index.pop("field_name", None)
         if tmp_index is not None:
-            return Index(self, "", tmp_index["params"])
+            return Index(self, field_name, tmp_index)
 
     def create_index(self, field_name, index_params, index_name="", **kwargs) -> Index:
         """

--- a/pymilvus_orm/index.py
+++ b/pymilvus_orm/index.py
@@ -57,12 +57,11 @@ class Index(object):
         self._kwargs = kwargs
 
         conn = self._get_connection()
-        index = conn.describe_index(self._collection.name, "")
-        if index is None:
+        index = conn.describe_index(self._collection.name)
+        if index is not None:
+            tmp_field_name = index.pop("field_name", None)
+        if index is None or index != index_params or tmp_field_name != field_name:
             conn.create_index(self._collection.name, self._field_name, self._index_params)
-        else:
-            if self._index_params != index["params"]:
-                raise Exception("The index already exists, but the index params is not the same as the passed in")
 
     def _get_connection(self):
         return self._collection._get_connection()


### PR DESCRIPTION
When create Index, if the index with the same field name and index
params already exist. dont raise exception. Otherwise, we create a new
index.

Signed-off-by: sunby <bingyi.sun@zilliz.com>