### PR TITLE
Remove soft link mock_milvus.py in examples/

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -49,7 +49,7 @@ If you want to install a specific version of PyMilvus-ORM:
 
 .. code-block:: shell
    
-   (venv) $ pip install pymilvus-orm==0.0.1
+   (venv) $ pip install pymilvus-orm==2.0.0rc1
 
 If you want to upgrade PyMilvus-ORM into the latest version published:
 

--- a/examples/mock_milvus.py
+++ b/examples/mock_milvus.py
@@ -1,1 +1,0 @@
-../tests/mock_milvus.py


### PR DESCRIPTION
Example files in examples/ are supposed to
work will real Milvus server not a mock one.

Fix a bug in documentation, version 0.0.1 is
not valid on any case and it's not recommended
to install 0.0.1.

Signed-off-by: yangxuan <xuan.yang@zilliz.com>