### PR TITLE
Change DataFrame validation location selection to integer-location

### DIFF
--- a/pymilvus_orm/collection.py
+++ b/pymilvus_orm/collection.py
@@ -58,7 +58,7 @@ def _check_data_schema(fields, data):
     if isinstance(data, pandas.DataFrame):
         for i, field in enumerate(fields):
             for j, _ in enumerate(data[field.name]):
-                tmp_type = infer_dtype_bydata(data[field.name][j])
+                tmp_type = infer_dtype_bydata(data[field.name].iloc[j])
                 if tmp_type != field.dtype:
                     raise DataNotMatchException(0, ExceptionsMessage.DataTypeInconsistent)
     else:


### PR DESCRIPTION
Resolves milvus-io/milvus#6677

Previously, Pandas dataframe validation iterated over the length of data present in a column, while making references to individual items by using the default location selection-by-index. This meant that validation would be successful when the dataframe index started from 0, but would cause errors when using sliced dataframes which started at a non-zero index, such as in milvus-io/milvus#6677

Switching to location selection-by-integer resolves this issue. 

Signed-off-by: NotRyan <ryan.chan@zilliz.com>