### PR TITLE
Add type conversion for searches done using dataframes, series, or ndarrays

### DIFF
--- a/pymilvus_orm/collection.py
+++ b/pymilvus_orm/collection.py
@@ -601,7 +601,8 @@ class Collection:
             raise DataTypeNotMatchException(0, ExceptionsMessage.ExprType % type(expr))
 
         conn = self._get_connection()
-        res = conn.search_with_expression(self._name, data, anns_field, param, limit, expr,
+        entities = Prepare.prepare_search_data(data)
+        res = conn.search_with_expression(self._name, entities, anns_field, param, limit, expr,
                                           partition_names, output_fields, timeout, **kwargs)
         if kwargs.get("_async", False):
             return SearchFuture(res)

--- a/pymilvus_orm/collection.py
+++ b/pymilvus_orm/collection.py
@@ -527,7 +527,7 @@ class Collection:
 
         :param data: The vectors of search data, the length of data is number of query (nq), the
                      dim of every vector in data must be equal to vector field's of collection.
-        :type  data: list[list[float]]
+        :type  data: list[list[float]]; pandas.Series with contents of list[float]; numpy.array[numpy.array[float]]
         :param anns_field: The vector field used to search of collection.
         :type  anns_field: str
         :param param: The parameters of search, such as ``nprobe``.

--- a/pymilvus_orm/prepare.py
+++ b/pymilvus_orm/prepare.py
@@ -81,8 +81,7 @@ class Prepare:
         if isinstance(data, pandas.DataFrame):
             if len(data.columns) != 1:
                 raise DataNotMatchException(0, ExceptionsMessage.FieldsNumInconsistent)
-            else:
-                entities = Prepare.prepare_search_data(data.iloc[:,0])
+            entities = Prepare.prepare_search_data(data.iloc[:, 0])
         elif isinstance(data, pandas.Series):
             entities = Prepare.prepare_search_data(data.values)
         elif isinstance(data, numpy.ndarray):

--- a/pymilvus_orm/prepare.py
+++ b/pymilvus_orm/prepare.py
@@ -71,3 +71,22 @@ class Prepare:
             raise DataNotMatchException(0, ExceptionsMessage.DataLengthsInconsistent)
 
         return entities
+
+    @classmethod
+    def prepare_search_data(cls, data):
+        if not isinstance(data, (list, tuple, pandas.DataFrame, pandas.Series, numpy.ndarray)):
+            raise DataTypeNotSupportException(0, ExceptionsMessage.DataTypeNotSupport)
+
+        entities = []
+        if isinstance(data, pandas.DataFrame):
+            if len(data.columns) != 1:
+                raise DataNotMatchException(0, ExceptionsMessage.FieldsNumInconsistent)
+            else:
+                entities = Prepare.prepare_search_data(data.iloc[:,0])
+        elif isinstance(data, pandas.Series):
+            entities = Prepare.prepare_search_data(data.values)
+        elif isinstance(data, numpy.ndarray):
+            entities = data.tolist()
+        else:
+            entities = data
+        return entities


### PR DESCRIPTION
We have some limited support for additional datatypes beyond lists when performing inserts. In previous RC versions of pymilvus, we also allowed users to conduct searches with these additional data types. For example, some of our bootcamp projects on version 2.0.0rc1 conduct searches with numpy.ndarrays. However, this functionality was broken with milvus-io/pymilvus#610, which adds stricter type-checks for search data in pymilvus since pymilvus itself isn't designed to have support for the extra data types.

This pull request adds some simple type conversions to pymilvus-orm when a user calls for a search using a pandas.dataframe, a pandas.series, or a numpy.ndarray, and converts the data into a list type usable by pymilvus. The function does not perform exhaustive checks to make sure the data is valid for searching; that is handled by pymilvus. 

Resolves #285

Signed-off-by: NotRyan <ryan.chan@zilliz.com>